### PR TITLE
Add Home URL and Source Code URL

### DIFF
--- a/orb.yml
+++ b/orb.yml
@@ -17,11 +17,13 @@ description: |
   Kubernetes operators security best practices.
   Deployment conformance to labeling, annotating, resource limits and much more ...
 
-  Orb source | https://github.com/alcideio/circleci-alcide-orb
+display:
+  source_url: https://github.com/alcideio/circleci-alcide-orb
+  home_url: https://www.alcide.io/
 
 # Orb Dependencies
 orbs:  
-  k8s: circleci/kubernetes@0.3.0
+  k8s: circleci/kubernetes@0.11
 
 commands:
   alcide_advisor_scan:


### PR DESCRIPTION
Display a link to your home page and the orb source natively in the Orb registry as a clickable link.

Also updated Kubernetes orb version